### PR TITLE
Fix incorrectly unvoiced dental fricative

### DIFF
--- a/src/Patches/GhostHints.cs
+++ b/src/Patches/GhostHints.cs
@@ -152,7 +152,7 @@ namespace TunicArchipelago {
             },
             { "Overworld Above Ruins", new List<HintGhost>() {
                new HintGhost("Overworld Redux", new Vector3(28.53184f, 36.0833f, -108.3734f), new Quaternion(0f, 0.7071068f, 0f, -0.7071068f), NPC.NPCAnimState.IDLE, $"I wuhz hIdi^ fruhm #uh \"SLIMES,\" buht yoo dOnt louk\nlIk wuhn uhv #ehm."),
-               new HintGhost("Overworld Redux", new Vector3(22.3667f, 27.9833f, -126.3728f), new Quaternion(0f, 0.7071068f, 0f, -0.7071068f), NPC.NPCAnimState.SIT, $"wAr did I lEv %aht kE..."),
+               new HintGhost("Overworld Redux", new Vector3(22.3667f, 27.9833f, -126.3728f), new Quaternion(0f, 0.7071068f, 0f, -0.7071068f), NPC.NPCAnimState.SIT, $"wAr did I lEv #aht kE..."),
                new HintGhost("Overworld Redux", new Vector3(51.20462f, 28.00694f, -129.722f), new Quaternion(0f, 1f, 0f, -4.371139E-08f), NPC.NPCAnimState.SIT, $"I %awt #aht Jehst wuhz ehmptE. how suhspi$is.") }
             },
             { "Early Overworld Spawns", new List<HintGhost>() {


### PR DESCRIPTION
I don't think this translation is right:

![image](https://github.com/silent-destroyer/tunic-randomizer-archipelago/assets/4490622/a34e0d8e-961a-47f9-838b-2c74787ee9e6)

The consonant at the beginning of "that" is a voiced dental fricative, but here it's being represented by the symbol for an unvoiced dental fricative.

I don't actually know how to build the mod and test that this works properly (I've never messed with BepInEx before), but the only change I made was replacing the first character of "that" in this line with the one I found representing the voiced dental fricative elsewhere.